### PR TITLE
Javadoc markup fixes

### DIFF
--- a/src/main/java/org/jboss/logmanager/ext/formatters/JsonFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/JsonFormatter.java
@@ -31,17 +31,16 @@ import javax.json.stream.JsonGeneratorFactory;
 
 /**
  * A formatter that outputs the record into JSON format optionally printing details.
- * <p/>
+ * <p>
  * Note that including details can be expensive in terms of calculating the caller.
- * <p/>
- * The details include;
+ * </p>
+ * <p>The details include;</p>
  * <ul>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceClassName() source class name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceFileName() source file name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceMethodName() source method name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceLineNumber() source line number}</li>
  * </ul>
- * <p/>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */

--- a/src/main/java/org/jboss/logmanager/ext/formatters/XmlFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/XmlFormatter.java
@@ -27,15 +27,15 @@ import javax.xml.stream.XMLStreamWriter;
 
 /**
  * A formatter that outputs the record in XML format.
- * <p/>
+ * <p>
  * The details include;
+ * </p>
  * <ul>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceClassName() source class name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceFileName() source file name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceMethodName() source method name}</li>
  * <li>{@link org.jboss.logmanager.ExtLogRecord#getSourceLineNumber() source line number}</li>
  * </ul>
- * <p/>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */


### PR DESCRIPTION
The Javadoc contains some invalid HTML markup which causes Javadoc
generation to fail with Java 8 because of the doclint which causes the
release to fail with Java 8.
