### PR TITLE
Add option to generate a simple string stacktrace in the json format

### DIFF
--- a/src/main/java/org/jboss/logmanager/ext/formatters/StructuredFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/StructuredFormatter.java
@@ -53,6 +53,7 @@ public abstract class StructuredFormatter extends ExtFormatter {
         EXCEPTION_FRAME_LINE("line"),
         EXCEPTION_FRAME_METHOD("method"),
         EXCEPTION_FRAMES("frames"),
+        EXCEPTION_STACK_TRACE("stackTrace"),
         EXCEPTION_MESSAGE("message"),
         LEVEL("level"),
         LOGGER_CLASS_NAME("loggerClassName"),


### PR DESCRIPTION
The default implementation of the stacktrace representation of a throwable just prints the content of the top level throwable. Which in most cases does not contain enough information about the error that accurred.
Therefore i added a 'simpleStackTrace' option to the JsonFormatter, which prints the whole stack trace of the throwable into the field 'stackTrace'.
