### PR TITLE
Allow stack traces to be formatted for fully detailed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <version.org.jboss.modules>1.3.0.Final</version.org.jboss.modules>
         <version.junit>4.12</version.junit>
 
+        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
@@ -108,6 +110,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>

--- a/src/main/java/org/jboss/logmanager/ext/formatters/StringBuilderWriter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/StringBuilderWriter.java
@@ -19,7 +19,6 @@
 
 package org.jboss.logmanager.ext.formatters;
 
-import java.io.IOException;
 import java.io.Writer;
 
 /**
@@ -62,39 +61,39 @@ final class StringBuilderWriter extends Writer {
     }
 
     @Override
-    public void write(final String str) throws IOException {
+    public void write(final String str) {
         builder.append(str);
     }
 
     @Override
-    public void write(final String str, final int off, final int len) throws IOException {
+    public void write(final String str, final int off, final int len) {
         builder.append(str, off, len);
     }
 
     @Override
-    public Writer append(final CharSequence csq) throws IOException {
+    public Writer append(final CharSequence csq) {
         builder.append(csq);
         return this;
     }
 
     @Override
-    public Writer append(final CharSequence csq, final int start, final int end) throws IOException {
+    public Writer append(final CharSequence csq, final int start, final int end) {
         builder.append(csq, start, end);
         return this;
     }
 
     @Override
-    public Writer append(final char c) throws IOException {
+    public Writer append(final char c) {
         builder.append(c);
         return this;
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush() {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
     }
 
     @Override

--- a/src/test/java/org/jboss/logmanager/ext/formatters/JsonFormatterTest.java
+++ b/src/test/java/org/jboss/logmanager/ext/formatters/JsonFormatterTest.java
@@ -65,9 +65,17 @@ public class JsonFormatterTest extends AbstractTest {
         record = createLogRecord(Level.ERROR, "Test formatted %s", "message");
         record.setLoggerName("org.jboss.logmanager.ext.test");
         record.setMillis(System.currentTimeMillis());
-        record.setThrown(new RuntimeException("Test Exception"));
+        final Throwable t = new RuntimeException("Test cause exception");
+        final Throwable dup = new IllegalStateException("Duplicate");
+        t.addSuppressed(dup);
+        final Throwable cause = new RuntimeException("Test Exception", t);
+        dup.addSuppressed(cause);
+        cause.addSuppressed(new IllegalArgumentException("Suppressed"));
+        cause.addSuppressed(dup);
+        record.setThrown(cause);
         record.putMdc("testMdcKey", "testMdcValue");
         record.setNdc("testNdc");
+        formatter.setExceptionOutputType(JsonFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED);
         compare(record, formatter);
     }
 


### PR DESCRIPTION
Introduce a way to print formatted, detailed or both types for exceptions.

Example JSON output for both.

```
{
    "timestamp":"2016-10-28T16:00:57.704-0700",
    "sequence":9,
    "loggerClassName":"org.jboss.logmanager.ext.formatters.JsonFormatterTest",
    "loggerName":"org.jboss.logmanager.ext.test",
    "level":"ERROR",
    "threadName":"main",
    "message":"Test formatted message",
    "threadId":1,
    "mdc":{
        "testMdcKey":"testMdcValue"
    },
    "ndc":"testNdc",
    "exception":[
        {
            "message":"Test Exception",
            "refId":1,
            "frames":[
                {
                    "class":"org.jboss.logmanager.ext.formatters.JsonFormatterTest",
                    "method":"testFormat",
                    "line":72
                },
                {
                    "class":"sun.reflect.NativeMethodAccessorImpl",
                    "method":"invoke0"
                },
                {
                    "class":"sun.reflect.NativeMethodAccessorImpl",
                    "method":"invoke",
                    "line":62
                },
                {
                    "class":"sun.reflect.DelegatingMethodAccessorImpl",
                    "method":"invoke",
                    "line":43
                },
                {
                    "class":"java.lang.reflect.Method",
                    "method":"invoke",
                    "line":498
                },
                {
                    "class":"org.junit.runners.model.FrameworkMethod$1",
                    "method":"runReflectiveCall",
                    "line":50
                },
                {
                    "class":"org.junit.internal.runners.model.ReflectiveCallable",
                    "method":"run",
                    "line":12
                },
                {
                    "class":"org.junit.runners.model.FrameworkMethod",
                    "method":"invokeExplosively",
                    "line":47
                },
                {
                    "class":"org.junit.internal.runners.statements.InvokeMethod",
                    "method":"evaluate",
                    "line":17
                },
                {
                    "class":"org.junit.internal.runners.statements.RunBefores",
                    "method":"evaluate",
                    "line":26
                },
                {
                    "class":"org.junit.runners.ParentRunner",
                    "method":"runLeaf",
                    "line":325
                },
                {
                    "class":"org.junit.runners.BlockJUnit4ClassRunner",
                    "method":"runChild",
                    "line":78
                },
                {
                    "class":"org.junit.runners.BlockJUnit4ClassRunner",
                    "method":"runChild",
                    "line":57
                },
                {
                    "class":"org.junit.runners.ParentRunner$3",
                    "method":"run",
                    "line":290
                },
                {
                    "class":"org.junit.runners.ParentRunner$1",
                    "method":"schedule",
                    "line":71
                },
                {
                    "class":"org.junit.runners.ParentRunner",
                    "method":"runChildren",
                    "line":288
                },
                {
                    "class":"org.junit.runners.ParentRunner",
                    "method":"access$000",
                    "line":58
                },
                {
                    "class":"org.junit.runners.ParentRunner$2",
                    "method":"evaluate",
                    "line":268
                },
                {
                    "class":"org.junit.runners.ParentRunner",
                    "method":"run",
                    "line":363
                },
                {
                    "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                    "method":"execute",
                    "line":283
                },
                {
                    "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                    "method":"executeWithRerun",
                    "line":173
                },
                {
                    "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                    "method":"executeTestSet",
                    "line":153
                },
                {
                    "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                    "method":"invoke",
                    "line":128
                },
                {
                    "class":"org.apache.maven.surefire.booter.ForkedBooter",
                    "method":"invokeProviderInSameClassLoader",
                    "line":203
                },
                {
                    "class":"org.apache.maven.surefire.booter.ForkedBooter",
                    "method":"runSuitesInProcess",
                    "line":155
                },
                {
                    "class":"org.apache.maven.surefire.booter.ForkedBooter",
                    "method":"main",
                    "line":103
                }
            ],
            "suppressed":[
                {
                    "message":"Suppressed",
                    "refId":2,
                    "frames":[
                        {
                            "class":"org.jboss.logmanager.ext.formatters.JsonFormatterTest",
                            "method":"testFormat",
                            "line":74
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke0"
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke",
                            "line":62
                        },
                        {
                            "class":"sun.reflect.DelegatingMethodAccessorImpl",
                            "method":"invoke",
                            "line":43
                        },
                        {
                            "class":"java.lang.reflect.Method",
                            "method":"invoke",
                            "line":498
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod$1",
                            "method":"runReflectiveCall",
                            "line":50
                        },
                        {
                            "class":"org.junit.internal.runners.model.ReflectiveCallable",
                            "method":"run",
                            "line":12
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod",
                            "method":"invokeExplosively",
                            "line":47
                        },
                        {
                            "class":"org.junit.internal.runners.statements.InvokeMethod",
                            "method":"evaluate",
                            "line":17
                        },
                        {
                            "class":"org.junit.internal.runners.statements.RunBefores",
                            "method":"evaluate",
                            "line":26
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runLeaf",
                            "line":325
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":78
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":57
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$3",
                            "method":"run",
                            "line":290
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$1",
                            "method":"schedule",
                            "line":71
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runChildren",
                            "line":288
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"access$000",
                            "line":58
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$2",
                            "method":"evaluate",
                            "line":268
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"run",
                            "line":363
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"execute",
                            "line":283
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeWithRerun",
                            "line":173
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeTestSet",
                            "line":153
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"invoke",
                            "line":128
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"invokeProviderInSameClassLoader",
                            "line":203
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"runSuitesInProcess",
                            "line":155
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"main",
                            "line":103
                        }
                    ]
                },
                {
                    "message":"Duplicate",
                    "refId":3,
                    "frames":[
                        {
                            "class":"org.jboss.logmanager.ext.formatters.JsonFormatterTest",
                            "method":"testFormat",
                            "line":70
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke0"
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke",
                            "line":62
                        },
                        {
                            "class":"sun.reflect.DelegatingMethodAccessorImpl",
                            "method":"invoke",
                            "line":43
                        },
                        {
                            "class":"java.lang.reflect.Method",
                            "method":"invoke",
                            "line":498
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod$1",
                            "method":"runReflectiveCall",
                            "line":50
                        },
                        {
                            "class":"org.junit.internal.runners.model.ReflectiveCallable",
                            "method":"run",
                            "line":12
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod",
                            "method":"invokeExplosively",
                            "line":47
                        },
                        {
                            "class":"org.junit.internal.runners.statements.InvokeMethod",
                            "method":"evaluate",
                            "line":17
                        },
                        {
                            "class":"org.junit.internal.runners.statements.RunBefores",
                            "method":"evaluate",
                            "line":26
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runLeaf",
                            "line":325
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":78
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":57
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$3",
                            "method":"run",
                            "line":290
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$1",
                            "method":"schedule",
                            "line":71
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runChildren",
                            "line":288
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"access$000",
                            "line":58
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$2",
                            "method":"evaluate",
                            "line":268
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"run",
                            "line":363
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"execute",
                            "line":283
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeWithRerun",
                            "line":173
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeTestSet",
                            "line":153
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"invoke",
                            "line":128
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"invokeProviderInSameClassLoader",
                            "line":203
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"runSuitesInProcess",
                            "line":155
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"main",
                            "line":103
                        }
                    ],
                    "suppressed":[
                        {
                            "circularReference":{
                                "message":"Test Exception",
                                "refId":0
                            }
                        }
                    ]
                }
            ],
            "causedBy":[
                {
                    "message":"Test cause exception",
                    "refId":4,
                    "frames":[
                        {
                            "class":"org.jboss.logmanager.ext.formatters.JsonFormatterTest",
                            "method":"testFormat",
                            "line":69
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke0"
                        },
                        {
                            "class":"sun.reflect.NativeMethodAccessorImpl",
                            "method":"invoke",
                            "line":62
                        },
                        {
                            "class":"sun.reflect.DelegatingMethodAccessorImpl",
                            "method":"invoke",
                            "line":43
                        },
                        {
                            "class":"java.lang.reflect.Method",
                            "method":"invoke",
                            "line":498
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod$1",
                            "method":"runReflectiveCall",
                            "line":50
                        },
                        {
                            "class":"org.junit.internal.runners.model.ReflectiveCallable",
                            "method":"run",
                            "line":12
                        },
                        {
                            "class":"org.junit.runners.model.FrameworkMethod",
                            "method":"invokeExplosively",
                            "line":47
                        },
                        {
                            "class":"org.junit.internal.runners.statements.InvokeMethod",
                            "method":"evaluate",
                            "line":17
                        },
                        {
                            "class":"org.junit.internal.runners.statements.RunBefores",
                            "method":"evaluate",
                            "line":26
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runLeaf",
                            "line":325
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":78
                        },
                        {
                            "class":"org.junit.runners.BlockJUnit4ClassRunner",
                            "method":"runChild",
                            "line":57
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$3",
                            "method":"run",
                            "line":290
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$1",
                            "method":"schedule",
                            "line":71
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"runChildren",
                            "line":288
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"access$000",
                            "line":58
                        },
                        {
                            "class":"org.junit.runners.ParentRunner$2",
                            "method":"evaluate",
                            "line":268
                        },
                        {
                            "class":"org.junit.runners.ParentRunner",
                            "method":"run",
                            "line":363
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"execute",
                            "line":283
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeWithRerun",
                            "line":173
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"executeTestSet",
                            "line":153
                        },
                        {
                            "class":"org.apache.maven.surefire.junit4.JUnit4Provider",
                            "method":"invoke",
                            "line":128
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"invokeProviderInSameClassLoader",
                            "line":203
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"runSuitesInProcess",
                            "line":155
                        },
                        {
                            "class":"org.apache.maven.surefire.booter.ForkedBooter",
                            "method":"main",
                            "line":103
                        }
                    ],
                    "suppressed":[
                        {
                            "circularReference":{
                                "message":"Duplicate",
                                "refId":2
                            }
                        }
                    ]
                }
            ]
        }
    ],
    "stackTrace":"java.lang.RuntimeException: Test Exception\n\tat org.jboss.logmanager.ext.formatters.JsonFormatterTest.testFormat(JsonFormatterTest.java:72)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)\n\tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)\n\tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:363)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)\n\tat org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)\n\tSuppressed: java.lang.IllegalArgumentException: Suppressed\n\t\tat org.jboss.logmanager.ext.formatters.JsonFormatterTest.testFormat(JsonFormatterTest.java:74)\n\t\t... 25 more\n\tSuppressed: java.lang.IllegalStateException: Duplicate\n\t\tat org.jboss.logmanager.ext.formatters.JsonFormatterTest.testFormat(JsonFormatterTest.java:70)\n\t\t... 25 more\n\t[CIRCULAR REFERENCE:java.lang.RuntimeException: Test Exception]\nCaused by: java.lang.RuntimeException: Test cause exception\n\tat org.jboss.logmanager.ext.formatters.JsonFormatterTest.testFormat(JsonFormatterTest.java:69)\n\t... 25 more\n\t[CIRCULAR REFERENCE:java.lang.IllegalStateException: Duplicate]\n",
    "sourceClassName":"sun.reflect.NativeMethodAccessorImpl",
    "sourceFileName":"NativeMethodAccessorImpl.java",
    "sourceMethodName":"invoke0",
    "sourceLineNumber":-2
}
```
