### PR TITLE
Updated org.jboss.logmanager version, added Travis CI yaml and added pass-through formatter for JSON log records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: java
+script: mvn clean verify
+jdk:
+  - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <version.javax.json>1.0</version.javax.json>
         <version.org.apache.felix>2.3.7</version.org.apache.felix>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.jboss.logmanager>1.5.4.Final</version.org.jboss.logmanager>
+        <version.org.jboss.logmanager>2.0.4.Final</version.org.jboss.logmanager>
         <version.org.jboss.modules>1.3.0.Final</version.org.jboss.modules>
         <version.junit>4.12</version.junit>
 

--- a/src/main/java/org/jboss/logmanager/ext/formatters/JsonPassThroughFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/JsonPassThroughFormatter.java
@@ -1,0 +1,56 @@
+package org.jboss.logmanager.ext.formatters;
+
+import org.jboss.logmanager.ExtFormatter;
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * <p>A {@link PassThroughFormatter} where the {@link PassThroughFormatter#passthrough(ExtLogRecord)}
+ * implementation includes conditions to determine whether {@link ExtLogRecord#getMessage()} returns
+ * a JSON message String.</p>
+ * <p>A JSON message String is identified as follows:
+ * <ul>
+ *   <li>Must start with "{"</li>
+ *   <li>Must end with "}" OR "}\n" OR "}\n\n"</li>
+ * </ul></p>
+ * <p>Created on 15/03/2017 by Shaun Willows</p>
+ *
+ * @author <a href="mailto:shaun.willows@iblocks.co.uk">Shaun Willows</a>
+ */
+public class JsonPassThroughFormatter<T extends ExtFormatter> extends PassThroughFormatter<T> {
+
+  private static final char JSON_START_CHAR = '{';
+
+  private static final char JSON_END_CHAR = '}';
+
+  private static final char CARRIAGE_RETURN = '\r';
+
+  /**
+   * Constructor
+   *
+   * @param delegateFormatter The delegate formatter to which {@link #format(ExtLogRecord)} defers if the conditions applied by
+   *                          {@link #passthrough(ExtLogRecord)} are not met.
+   */
+  public JsonPassThroughFormatter(T delegateFormatter) {
+    super(delegateFormatter);
+  }
+
+  /**
+   * Includes conditions to determine whether {@link ExtLogRecord#getMessage()} returns
+   * a JSON message String.
+   * <p>A JSON message String is identified as follows:
+   * <ul>
+   *   <li>Must start with "{"</li>
+   *   <li>Must end with "}" OR "}\n" OR "}\n\n"</li>
+   * </ul></p>
+   * @param extLogRecord The {@link ExtLogRecord} to be formatted
+   * @return true if {@link ExtLogRecord#getMessage()} returns a JSON message String.
+   */
+  @Override
+  protected boolean passthrough(ExtLogRecord extLogRecord) {
+    String message = extLogRecord.getMessage();
+    int length = message.length();
+    return length >= 2 && message.charAt(0) == JSON_START_CHAR && (message.charAt(length - 1) == JSON_END_CHAR || (
+            message.charAt(length - 1) == LINE_FEED && (message.charAt(length - 2) == JSON_END_CHAR || (
+                    message.charAt(length - 2) == CARRIAGE_RETURN && message.charAt(length - 3) == JSON_END_CHAR))));
+  }
+}

--- a/src/main/java/org/jboss/logmanager/ext/formatters/LogstashJsonPassThroughFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/LogstashJsonPassThroughFormatter.java
@@ -1,0 +1,185 @@
+package org.jboss.logmanager.ext.formatters;
+
+import org.jboss.logmanager.ExtFormatter;
+import org.jboss.logmanager.ext.util.ValueParser;
+
+/**
+ * <p>A {@link JsonPassThroughFormatter} of type {@link LogstashFormatter}</p>
+ * <p>Created on 15/03/2017 by Shaun Willows</p>
+ *
+ * @author <a href="mailto:shaun.willows@iblocks.co.uk">Shaun Willows</a>
+ */
+public class LogstashJsonPassThroughFormatter extends JsonPassThroughFormatter<LogstashFormatter> {
+
+  /**
+   * Constructor. Calls JsonPassThroughFormatter{@link JsonPassThroughFormatter#JsonPassThroughFormatter(ExtFormatter)} with an
+   * instance of {@link LogstashFormatter}.
+   */
+  public LogstashJsonPassThroughFormatter() {
+    super(new LogstashFormatter());
+  }
+
+  /**
+   * Returns the version being used for the {@code @version} property.
+   *
+   * @return the version being used
+   */
+  public int getVersion() {
+    return getDelegateFormatter().getVersion();
+  }
+
+  /**
+   * Sets the version to use for the {@code @version} property.
+   *
+   * @param version the version to use
+   */
+  public void setVersion(final int version) {
+    getDelegateFormatter().setVersion(version);
+  }
+
+  /**
+   * Indicates whether or not pretty printing is enabled.
+   *
+   * @return {@code true} if pretty printing is enabled, otherwise {@code false}
+   */
+  public boolean isPrettyPrint() {
+    return getDelegateFormatter().isPrettyPrint();
+  }
+
+  /**
+   * Turns on or off pretty printing.
+   *
+   * @param b {@code true} to turn on pretty printing or {@code false} to turn it off
+   */
+  public void setPrettyPrint(final boolean b) {
+    getDelegateFormatter().setPrettyPrint(b);
+  }
+
+
+  /**
+   * Indicates whether or not an EOL ({@code \n}) character will appended to the formatted message.
+   *
+   * @return {@code true} to append the EOL character, otherwise {@code false}
+   */
+  public boolean isAppendEndOfLine() {
+    return getDelegateFormatter().isAppendEndOfLine();
+  }
+
+  /**
+   * Set whether or not an EOL ({@code \n}) character will appended to the formatted message.
+   *
+   * @param addEolChar {@code true} to append the EOL character, otherwise {@code false}
+   */
+  public void setAppendEndOfLine(final boolean addEolChar) {
+    getDelegateFormatter().setAppendEndOfLine(addEolChar);
+  }
+
+  /**
+   * Returns the value set for meta data.
+   * <p>
+   * The value is a string where key/value pairs are separated by commas. The key and value are separated by an
+   * equal sign.
+   * </p>
+   *
+   * @return the meta data string or {@code null} if one was not set
+   * @see ValueParser#stringToMap(String)
+   */
+  public String getMetaData() {
+    return getDelegateFormatter().getMetaData();
+  }
+
+  /**
+   * Sets the meta data to use in the structured format.
+   * <p>
+   * The value is a string where key/value pairs are separated by commas. The key and value are separated by an
+   * equal sign.
+   * </p>
+   *
+   * @param metaData the meta data to set or {@code null} to not format any meta data
+   * @see ValueParser#stringToMap(String)
+   */
+  public synchronized void setMetaData(final String metaData) {
+    getDelegateFormatter().setMetaData(metaData);
+  }
+
+  /**
+   * Gets the current date format.
+   *
+   * @return the current date format
+   */
+  public String getDateFormat() {
+    return getDelegateFormatter().getDateFormat();
+  }
+
+  /**
+   * Sets the pattern to use when formatting the date. The pattern must be a valid {@link java.text.SimpleDateFormat}
+   * pattern.
+   * <p>
+   * If the pattern is {@code null} a default pattern will be used.
+   * </p>
+   *
+   * @param pattern the pattern to use
+   */
+  public void setDateFormat(final String pattern) {
+    getDelegateFormatter().setDateFormat(pattern);
+  }
+
+  /**
+   * Indicates whether or not details should be printed.
+   *
+   * @return {@code true} if details should be printed, otherwise {@code false}
+   */
+  public boolean isPrintDetails() {
+    return getDelegateFormatter().isPrintDetails();
+  }
+
+  /**
+   * Sets whether or not details should be printed.
+   * <p>
+   * Printing the details can be expensive as the values are retrieved from the caller. The details include the
+   * source class name, source file name, source method name and source line number.
+   * </p>
+   *
+   * @param printDetails {@code true} if details should be printed
+   */
+  public void setPrintDetails(final boolean printDetails) {
+    getDelegateFormatter().setPrintDetails(printDetails);
+  }
+
+  /**
+   * Get the current output type for exceptions.
+   *
+   * @return the output type for exceptions
+   */
+  public StructuredFormatter.ExceptionOutputType getExceptionOutputType() {
+    return getDelegateFormatter().getExceptionOutputType();
+  }
+
+  /**
+   * Set the output type for exceptions. The default is {@link StructuredFormatter.ExceptionOutputType#DETAILED DETAILED}.
+   *
+   * @param exceptionOutputType the desired output type, if {@code null} {@link StructuredFormatter.ExceptionOutputType#DETAILED} is used
+   */
+  public void setExceptionOutputType(final StructuredFormatter.ExceptionOutputType exceptionOutputType) {
+    getDelegateFormatter().setExceptionOutputType(exceptionOutputType);
+  }
+
+  /**
+   * Checks the exception output type and determines if detailed output should be written.
+   *
+   * @return {@code true} if detailed output should be written, otherwise {@code false}
+   */
+  protected boolean isDetailedExceptionOutputType() {
+    return getDelegateFormatter().isDetailedExceptionOutputType();
+  }
+
+  /**
+   * Checks the exception output type and determines if formatted output should be written. The formatted output is
+   * equivalent to {@link Throwable#printStackTrace()}.
+   *
+   * @return {@code true} if formatted exception output should be written, otherwide {@code false}
+   */
+  protected boolean isFormattedExceptionOutputType() {
+    return getDelegateFormatter().isFormattedExceptionOutputType();
+  }
+}

--- a/src/main/java/org/jboss/logmanager/ext/formatters/PassThroughFormatter.java
+++ b/src/main/java/org/jboss/logmanager/ext/formatters/PassThroughFormatter.java
@@ -1,0 +1,74 @@
+package org.jboss.logmanager.ext.formatters;
+
+import org.jboss.logmanager.ExtFormatter;
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * <p>A formatter where {@link #format(ExtLogRecord)} returns the raw message from
+ * {@link ExtLogRecord#getMessage()} if the conditions applied by
+ * {@link #passthrough(ExtLogRecord)} are met, other it delegates to
+ * {@link #getDelegateFormatter() delegateFormatter}</p>
+ * <p>This formatter is useful when the message has already been formatted appropriately
+ * prior to reaching the JBoss Log Manager formatter.</p>
+ * <p>Created on 15/03/2017 by Shaun Willows</p>
+ *
+ * @author <a href="mailto:shaun.willows@iblocks.co.uk">Shaun Willows</a>
+ */
+public abstract class PassThroughFormatter<T extends ExtFormatter> extends ExtFormatter {
+
+  protected static final char LINE_FEED = '\n';
+
+  private T delegateFormatter;
+
+
+  /**
+   * Constructor
+   *
+   * @param delegateFormatter The delegate formatter to which {@link #format(ExtLogRecord)} defers if the conditions applied by
+   *                          {@link #passthrough(ExtLogRecord)} are not met.
+   */
+  public PassThroughFormatter(T delegateFormatter) {
+    this.delegateFormatter = delegateFormatter;
+  }
+
+  /**
+   * @return The delegate formatter to which {@link #format(ExtLogRecord)} defers if the conditions applied by
+   * {@link #passthrough(ExtLogRecord)} are not met.
+   */
+  protected T getDelegateFormatter() {
+    return delegateFormatter;
+  }
+
+  /**
+   * Applies a set of conditions to determine whether the the raw message from
+   * {@link ExtLogRecord#getMessage()} should be returned by {@link #format(ExtLogRecord)},
+   * whether it should defer to {@link #getDelegateFormatter() delegateFormatter}.
+   *
+   * @param extLogRecord The {@link ExtLogRecord} to be formatted
+   * @return true if the raw message from {@link ExtLogRecord#getMessage()} should be returned
+   * by {@link #format(ExtLogRecord)}
+   */
+  protected abstract boolean passthrough(ExtLogRecord extLogRecord);
+
+  /**
+   * Returns the raw message from {@link ExtLogRecord#getMessage()} if the conditions applied by
+   * {@link #passthrough(ExtLogRecord)} are met, other it delegates to {@link #getDelegateFormatter() delegateFormatter}
+   * to generate the formatted message.
+   *
+   * @param extLogRecord The {@link ExtLogRecord} to be formatted
+   * @return Either {@link ExtLogRecord#getMessage()} or the result of {@link ExtFormatter#format(ExtLogRecord)} for
+   * {@link #getDelegateFormatter() delegateFormatter}
+   */
+  @Override
+  public String format(ExtLogRecord extLogRecord) {
+    if (passthrough(extLogRecord)) {
+      String message = extLogRecord.getMessage();
+      if (message.charAt(message.length() - 1) != LINE_FEED) {
+        message += LINE_FEED;
+      }
+      return message;
+
+    }
+    return delegateFormatter.format(extLogRecord);
+  }
+}

--- a/src/test/java/org/jboss/logmanager/ext/AbstractTest.java
+++ b/src/test/java/org/jboss/logmanager/ext/AbstractTest.java
@@ -50,13 +50,6 @@ public abstract class AbstractTest {
         return record;
     }
 
-    protected static void compareMaps(final Map<String, String> m1, final Map<String, String> m2) {
-        String failureMessage = String.format("Keys did not match%n%s%n%s%n", m1.keySet(), m2.keySet());
-        Assert.assertTrue(failureMessage, m1.keySet().containsAll(m2.keySet()));
-        failureMessage = String.format("Values did not match%n%s%n%s%n", m1.values(), m2.values());
-        Assert.assertTrue(failureMessage, m1.values().containsAll(m2.values()));
-    }
-
     public static class MapBuilder<K, V> {
         private final Map<K, V> result;
 

--- a/src/test/java/org/jboss/logmanager/ext/TestUtil.java
+++ b/src/test/java/org/jboss/logmanager/ext/TestUtil.java
@@ -1,0 +1,21 @@
+package org.jboss.logmanager.ext;
+
+import org.junit.Assert;
+
+import java.util.Map;
+
+/**
+ * <p>Provides ...</p>
+ * <p>
+ * <p>Created on 15/03/2017 by willows_s</p>
+ *
+ * @author <a href="mailto:willows_s@iblocks.co.uk">willows_s</a>
+ */
+public class TestUtil {
+  public static void compareMaps(final Map<String, String> m1, final Map<String, String> m2) {
+    String failureMessage = String.format("Keys did not match%n%s%n%s%n", m1.keySet(), m2.keySet());
+    Assert.assertTrue(failureMessage, m1.keySet().containsAll(m2.keySet()));
+    failureMessage = String.format("Values did not match%n%s%n%s%n", m1.values(), m2.values());
+    Assert.assertTrue(failureMessage, m1.values().containsAll(m2.values()));
+  }
+}

--- a/src/test/java/org/jboss/logmanager/ext/formatters/JsonFormatterTest.java
+++ b/src/test/java/org/jboss/logmanager/ext/formatters/JsonFormatterTest.java
@@ -19,37 +19,26 @@
 
 package org.jboss.logmanager.ext.formatters;
 
-import java.io.StringReader;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
-import javax.json.JsonValue.ValueType;
 
-import org.jboss.logmanager.ExtFormatter;
 import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.Level;
 import org.jboss.logmanager.ext.AbstractTest;
 import org.jboss.logmanager.ext.formatters.StructuredFormatter.Key;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.jboss.logmanager.ext.formatters.JsonTestUtil.compare;
+import static org.jboss.logmanager.ext.formatters.JsonTestUtil.compareLogstash;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class JsonFormatterTest extends AbstractTest {
-    private static final Map<Key, String> KEY_OVERRIDES = new HashMap<>();
 
-    @Before
+  @Before
     public void before() {
-        KEY_OVERRIDES.clear();
+        JsonTestUtil.KEY_OVERRIDES.clear();
     }
 
     @Test
@@ -100,7 +89,7 @@ public class JsonFormatterTest extends AbstractTest {
 
     @Test
     public void testLogstashFormat() throws Exception {
-        KEY_OVERRIDES.put(Key.TIMESTAMP, "@timestamp");
+        JsonTestUtil.KEY_OVERRIDES.put(Key.TIMESTAMP, "@timestamp");
         final LogstashFormatter formatter = new LogstashFormatter();
         formatter.setPrintDetails(true);
         ExtLogRecord record = createLogRecord("Test formatted %s", "message");
@@ -119,114 +108,4 @@ public class JsonFormatterTest extends AbstractTest {
         compareLogstash(record, formatter, 2);
     }
 
-    private static int getInt(final JsonObject json, final Key key) {
-        final String name = getKey(key);
-        if (json.containsKey(name) && !json.isNull(name)) {
-            return json.getInt(name);
-        }
-        return 0;
-    }
-
-    private static long getLong(final JsonObject json, final Key key) {
-        final String name = getKey(key);
-        if (json.containsKey(name) && !json.isNull(name)) {
-            return json.getJsonNumber(name).longValue();
-        }
-        return 0L;
-    }
-
-    private static String getString(final JsonObject json, final Key key) {
-        final String name = getKey(key);
-        if (json.containsKey(name) && !json.isNull(name)) {
-            return json.getString(name);
-        }
-        return null;
-    }
-
-    private static Map<String, String> getMap(final JsonObject json, final Key key) {
-        final String name = getKey(key);
-        if (json.containsKey(name) && !json.isNull(name)) {
-            final Map<String, String> result = new LinkedHashMap<>();
-            final JsonObject mdcObject = json.getJsonObject(name);
-            for (String k : mdcObject.keySet()) {
-                final JsonValue value = mdcObject.get(k);
-                if (value.getValueType() == ValueType.STRING) {
-                    result.put(k, value.toString().replace("\"", ""));
-                } else {
-                    result.put(k, value.toString());
-                }
-            }
-            return result;
-        }
-        return Collections.emptyMap();
-    }
-
-    private static String getKey(final Key key) {
-        if (KEY_OVERRIDES.containsKey(key)) {
-            return KEY_OVERRIDES.get(key);
-        }
-        return key.getKey();
-    }
-
-    private static void compare(final ExtLogRecord record, final ExtFormatter formatter) {
-        compare(record, formatter.format(record));
-    }
-
-    private static void compare(final ExtLogRecord record, final ExtFormatter formatter, final Map<String, String> metaData) {
-        compare(record, formatter.format(record), metaData);
-    }
-
-    private static void compare(final ExtLogRecord record, final String jsonString) {
-        compare(record, jsonString, null);
-    }
-
-    private static void compare(final ExtLogRecord record, final String jsonString, final Map<String, String> metaData) {
-        final JsonReader reader = Json.createReader(new StringReader(jsonString));
-        final JsonObject json = reader.readObject();
-        compare(record, json, metaData);
-    }
-
-    private static void compareLogstash(final ExtLogRecord record, final ExtFormatter formatter, final int version) {
-        compareLogstash(record, formatter.format(record), version);
-    }
-
-    private static void compareLogstash(final ExtLogRecord record, final String jsonString, final int version) {
-        final JsonReader reader = Json.createReader(new StringReader(jsonString));
-        final JsonObject json = reader.readObject();
-        compare(record, json, null);
-        final String name = "@version";
-        int foundVersion = 0;
-        if (json.containsKey(name) && !json.isNull(name)) {
-            foundVersion = json.getInt(name);
-        }
-        Assert.assertEquals(version, foundVersion);
-    }
-
-    private static void compare(final ExtLogRecord record, final JsonObject json, final Map<String, String> metaData) {
-        Assert.assertEquals(record.getLevel(), Level.parse(getString(json, Key.LEVEL)));
-        Assert.assertEquals(record.getLoggerClassName(), getString(json, Key.LOGGER_CLASS_NAME));
-        Assert.assertEquals(record.getLoggerName(), getString(json, Key.LOGGER_NAME));
-        compareMaps(record.getMdcCopy(), getMap(json, Key.MDC));
-        Assert.assertEquals(record.getFormattedMessage(), getString(json, Key.MESSAGE));
-        Assert.assertEquals(
-                new SimpleDateFormat(StructuredFormatter.DEFAULT_DATE_FORMAT).format(new Date(record.getMillis())),
-                getString(json, Key.TIMESTAMP));
-        Assert.assertEquals(record.getNdc(), getString(json, Key.NDC));
-        // Assert.assertEquals(record.getResourceBundle());
-        // Assert.assertEquals(record.getResourceBundleName());
-        // Assert.assertEquals(record.getResourceKey());
-        Assert.assertEquals(record.getSequenceNumber(), getLong(json, Key.SEQUENCE));
-        Assert.assertEquals(record.getSourceClassName(), getString(json, Key.SOURCE_CLASS_NAME));
-        Assert.assertEquals(record.getSourceFileName(), getString(json, Key.SOURCE_FILE_NAME));
-        Assert.assertEquals(record.getSourceLineNumber(), getInt(json, Key.SOURCE_LINE_NUMBER));
-        Assert.assertEquals(record.getSourceMethodName(), getString(json, Key.SOURCE_METHOD_NAME));
-        Assert.assertEquals(record.getThreadID(), getInt(json, Key.THREAD_ID));
-        Assert.assertEquals(record.getThreadName(), getString(json, Key.THREAD_NAME));
-        if (metaData != null) {
-            for (String key : metaData.keySet()) {
-                Assert.assertEquals(metaData.get(key), json.getString(key));
-            }
-        }
-        // TODO (jrp) stack trace should be validated
-    }
 }

--- a/src/test/java/org/jboss/logmanager/ext/formatters/JsonTestUtil.java
+++ b/src/test/java/org/jboss/logmanager/ext/formatters/JsonTestUtil.java
@@ -1,0 +1,137 @@
+package org.jboss.logmanager.ext.formatters;
+
+import org.jboss.logmanager.ExtFormatter;
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.jboss.logmanager.ext.TestUtil;
+import org.junit.Assert;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import java.io.StringReader;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/**
+ * <p>Provides ...</p>
+ * <p>
+ * <p>Created on 15/03/2017 by willows_s</p>
+ *
+ * @author <a href="mailto:willows_s@iblocks.co.uk">willows_s</a>
+ */
+public class JsonTestUtil {
+  static final Map<StructuredFormatter.Key, String> KEY_OVERRIDES = new HashMap<>();
+
+  private static int getInt(final JsonObject json, final StructuredFormatter.Key key) {
+      final String name = getKey(key);
+      if (json.containsKey(name) && !json.isNull(name)) {
+          return json.getInt(name);
+      }
+      return 0;
+  }
+
+  private static long getLong(final JsonObject json, final StructuredFormatter.Key key) {
+      final String name = getKey(key);
+      if (json.containsKey(name) && !json.isNull(name)) {
+          return json.getJsonNumber(name).longValue();
+      }
+      return 0L;
+  }
+
+  private static String getString(final JsonObject json, final StructuredFormatter.Key key) {
+      final String name = getKey(key);
+      if (json.containsKey(name) && !json.isNull(name)) {
+          return json.getString(name);
+      }
+      return null;
+  }
+
+  private static Map<String, String> getMap(final JsonObject json, final StructuredFormatter.Key key) {
+      final String name = getKey(key);
+      if (json.containsKey(name) && !json.isNull(name)) {
+          final Map<String, String> result = new LinkedHashMap<>();
+          final JsonObject mdcObject = json.getJsonObject(name);
+          for (String k : mdcObject.keySet()) {
+              final JsonValue value = mdcObject.get(k);
+              if (value.getValueType() == JsonValue.ValueType.STRING) {
+                  result.put(k, value.toString().replace("\"", ""));
+              } else {
+                  result.put(k, value.toString());
+              }
+          }
+          return result;
+      }
+      return Collections.emptyMap();
+  }
+
+  private static String getKey(final StructuredFormatter.Key key) {
+      if (KEY_OVERRIDES.containsKey(key)) {
+          return KEY_OVERRIDES.get(key);
+      }
+      return key.getKey();
+  }
+
+  static void compare(final ExtLogRecord record, final ExtFormatter formatter) {
+      compare(record, formatter.format(record));
+  }
+
+  static void compare(final ExtLogRecord record, final ExtFormatter formatter, final Map<String, String> metaData) {
+      compare(record, formatter.format(record), metaData);
+  }
+
+  private static void compare(final ExtLogRecord record, final String jsonString) {
+      compare(record, jsonString, null);
+  }
+
+  private static void compare(final ExtLogRecord record, final String jsonString, final Map<String, String> metaData) {
+      final JsonReader reader = Json.createReader(new StringReader(jsonString));
+      final JsonObject json = reader.readObject();
+      compare(record, json, metaData);
+  }
+
+  static void compareLogstash(final ExtLogRecord record, final ExtFormatter formatter, final int version) {
+      compareLogstash(record, formatter.format(record), version);
+  }
+
+  private static void compareLogstash(final ExtLogRecord record, final String jsonString, final int version) {
+      final JsonReader reader = Json.createReader(new StringReader(jsonString));
+      final JsonObject json = reader.readObject();
+      compare(record, json, null);
+      final String name = "@version";
+      int foundVersion = 0;
+      if (json.containsKey(name) && !json.isNull(name)) {
+          foundVersion = json.getInt(name);
+      }
+      Assert.assertEquals(version, foundVersion);
+  }
+
+  private static void compare(final ExtLogRecord record, final JsonObject json, final Map<String, String> metaData) {
+      Assert.assertEquals(record.getLevel(), Level.parse(getString(json, StructuredFormatter.Key.LEVEL)));
+      Assert.assertEquals(record.getLoggerClassName(), getString(json, StructuredFormatter.Key.LOGGER_CLASS_NAME));
+      Assert.assertEquals(record.getLoggerName(), getString(json, StructuredFormatter.Key.LOGGER_NAME));
+      TestUtil.compareMaps(record.getMdcCopy(), getMap(json, StructuredFormatter.Key.MDC));
+      Assert.assertEquals(record.getFormattedMessage(), getString(json, StructuredFormatter.Key.MESSAGE));
+      Assert.assertEquals(
+              new SimpleDateFormat(StructuredFormatter.DEFAULT_DATE_FORMAT).format(new Date(record.getMillis())),
+              getString(json, StructuredFormatter.Key.TIMESTAMP));
+      Assert.assertEquals(record.getNdc(), getString(json, StructuredFormatter.Key.NDC));
+      // Assert.assertEquals(record.getResourceBundle());
+      // Assert.assertEquals(record.getResourceBundleName());
+      // Assert.assertEquals(record.getResourceKey());
+      Assert.assertEquals(record.getSequenceNumber(), getLong(json, StructuredFormatter.Key.SEQUENCE));
+      Assert.assertEquals(record.getSourceClassName(), getString(json, StructuredFormatter.Key.SOURCE_CLASS_NAME));
+      Assert.assertEquals(record.getSourceFileName(), getString(json, StructuredFormatter.Key.SOURCE_FILE_NAME));
+      Assert.assertEquals(record.getSourceLineNumber(), getInt(json, StructuredFormatter.Key.SOURCE_LINE_NUMBER));
+      Assert.assertEquals(record.getSourceMethodName(), getString(json, StructuredFormatter.Key.SOURCE_METHOD_NAME));
+      Assert.assertEquals(record.getThreadID(), getInt(json, StructuredFormatter.Key.THREAD_ID));
+      Assert.assertEquals(record.getThreadName(), getString(json, StructuredFormatter.Key.THREAD_NAME));
+      if (metaData != null) {
+          for (String key : metaData.keySet()) {
+              Assert.assertEquals(metaData.get(key), json.getString(key));
+          }
+      }
+      // TODO (jrp) stack trace should be validated
+  }
+}

--- a/src/test/java/org/jboss/logmanager/ext/formatters/LogstashJsonPassThroughFormatterTest.java
+++ b/src/test/java/org/jboss/logmanager/ext/formatters/LogstashJsonPassThroughFormatterTest.java
@@ -1,0 +1,63 @@
+package org.jboss.logmanager.ext.formatters;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.jboss.logmanager.ext.AbstractTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.jboss.logmanager.ext.formatters.JsonTestUtil.compareLogstash;
+
+/**
+ * <p>Provides ...</p>
+ * <p>
+ * <p>Created on 15/03/2017 by willows_s</p>
+ *
+ * @author <a href="mailto:willows_s@iblocks.co.uk">willows_s</a>
+ */
+public class LogstashJsonPassThroughFormatterTest extends AbstractTest {
+
+  @Test
+  public void testLogstashFormat() throws Exception {
+    JsonTestUtil.KEY_OVERRIDES.put(StructuredFormatter.Key.TIMESTAMP, "@timestamp");
+    final LogstashJsonPassThroughFormatter formatter = new LogstashJsonPassThroughFormatter();
+    formatter.setPrintDetails(true);
+    ExtLogRecord record = createLogRecord("Test formatted %s", "message");
+    compareLogstash(record, formatter, 1);
+
+    record = createLogRecord("Test Message");
+    formatter.setVersion(2);
+    compareLogstash(record, formatter, 2);
+
+    record = createLogRecord(Level.ERROR, "Test formatted %s", "message");
+    record.setLoggerName("org.jboss.logmanager.ext.test");
+    record.setMillis(System.currentTimeMillis());
+    record.setThrown(new RuntimeException("Test Exception"));
+    record.putMdc("testMdcKey", "testMdcValue");
+    record.setNdc("testNdc");
+    compareLogstash(record, formatter, 2);
+
+    record = createLogRecord("{");
+    formatter.setVersion(2);
+    compareLogstash(record, formatter, 2);
+  }
+
+  @Test
+  public void testLogstashFormatAlreadyJson() throws Exception {
+    final LogstashJsonPassThroughFormatter formatter = new LogstashJsonPassThroughFormatter();
+    String message = "{\"testField1\":\"testField2\"}";
+    ExtLogRecord record = createLogRecord(message);
+    String result = formatter.format(record);
+    Assert.assertEquals(message + "\n", result);
+
+    message = "{\"testField1\":\"testField2\"}\n";
+    record = createLogRecord(message);
+    result = formatter.format(record);
+    Assert.assertEquals(message, result);
+
+    message = "{\"testField1\":\"testField2\"}\r\n";
+    record = createLogRecord(message);
+    result = formatter.format(record);
+    Assert.assertEquals(message, result);
+  }
+}

--- a/src/test/java/org/jboss/logmanager/ext/util/ValueParserTest.java
+++ b/src/test/java/org/jboss/logmanager/ext/util/ValueParserTest.java
@@ -25,6 +25,8 @@ import org.jboss.logmanager.ext.AbstractTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.jboss.logmanager.ext.TestUtil.compareMaps;
+
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */


### PR DESCRIPTION
Changes:
* Updated org.jboss.logmanager version
* Added Travis CI yaml
* Added pass through formatter for JSON log records (in particular LogStash records). The primary purpose of adding these loggers is to allow other logging frameworks to format log messages and log to the console (System.out). The JBoss Log Manager will intercept messages written to the console (System.out), and thus attempt to format the already formatted messages. The pass through formatter performs a number of checks against a log record. If the conditions are met, the raw message (ExtLogRecord.getMessage()) is returned from the format method. If the conditions are not met, it defers formatting to a delegate ExtFormatter instance (in this case LogstashFormatter).